### PR TITLE
Check curl only when the command is run.

### DIFF
--- a/forex
+++ b/forex
@@ -42,13 +42,14 @@ usage() {
     exit
 }
 
-if [ -z "$1" ]; then
+if [[ -x `which curl` ]]; then
+  if [ -z "$1" ]; then
     echo $CBBANNER
     printout getcb
     echo -e "\n$KBZBANNER"
     printout getkbz
 
-else
+  else
     case "$1" in
          -h|--help)
             usage
@@ -72,4 +73,7 @@ else
             usage
             ;;
     esac
+  fi
+else
+  echo "forex needs curl to work. Install curl first." >&2
 fi

--- a/makefile
+++ b/makefile
@@ -1,5 +1,4 @@
 install: uninstall
-	apt-get install curl
 	cp -fv ./forex /usr/local/bin
 
 uninstall:


### PR DESCRIPTION
`apt-get install curl` on makefile is so cruel for us, OSX guys. :sob:

I think just checking `curl` before running the command is enough.

Cheers
